### PR TITLE
[codex] Upgrade publication list UI

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -56,6 +56,27 @@ Pushing changes to `publications.bib` triggers `.github/workflows/import-publica
 
 Review the generated PR before merging.
 
+Optional publication display fields can be added manually to the generated English and Chinese publication bundles after bibliographic facts are confirmed:
+
+```yaml
+cover_image: cover.webp
+cover_full_image: cover-full.webp
+impact_factor: 8.3
+jcr_quartile: Q1
+citation_count: 42
+research_areas:
+  - Infrared Sensing
+badges:
+  - esi_highly_cited
+  - journal_cover
+google_scholar_url: https://scholar.google.com/...
+orcid_url: https://orcid.org/...
+```
+
+Keep these fields local and manually verified. Google Scholar is useful as a discovery checklist and external link, but it is not a stable automatic source of truth for this static Hugo site. Impact factor, JCR quartile, ESI highly cited status, and journal cover status should only be shown after Professor Tang or another maintainer confirms them.
+
+Publication cover thumbnails are manually curated assets placed in the same publication folder as `index.md`. Prefer WebP or JPG thumbnails under about 80 KB for the list view; add `cover_full_image` only when a higher-resolution image is useful for click-through viewing. Do not automatically download publisher images or infer a journal cover badge from a thumbnail.
+
 ### Chinese Content
 
 The Hugo language configuration includes `zh` with `contentDir: content/zh`, and the site header language switch is enabled.

--- a/assets/js/publication-mvp.js
+++ b/assets/js/publication-mvp.js
@@ -1,0 +1,95 @@
+(function () {
+  function onReady(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback);
+    } else {
+      callback();
+    }
+  }
+
+  function publicationValue(item, metric) {
+    const attr = metric === 'impact' ? 'data-pub-impact' : metric === 'citations' ? 'data-pub-citations' : 'data-pub-year';
+    const raw = item.getAttribute(attr);
+    if (raw === null || raw === '') return null;
+    const value = Number.parseFloat(raw);
+    return Number.isFinite(value) ? value : null;
+  }
+
+  function setSortValues(grid, metric, direction) {
+    grid.querySelectorAll('.isotope-item').forEach((item) => {
+      const value = publicationValue(item, metric);
+      const sortValue = value === null ? Number.MAX_SAFE_INTEGER : direction === 'asc' ? value : -value;
+      item.setAttribute('data-sort-current', String(sortValue));
+    });
+  }
+
+  function applyPublicationSort(grid, keySelect, directionSelect) {
+    if (!window.jQuery) return;
+    const $grid = window.jQuery(grid);
+    if (!$grid.data('isotope')) return;
+
+    setSortValues(grid, keySelect.value, directionSelect.value);
+    $grid.isotope({
+      getSortData: {
+        current: function (itemElem) {
+          const value = Number.parseFloat(itemElem.getAttribute('data-sort-current'));
+          return Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER;
+        },
+      },
+      sortBy: 'current',
+      sortAscending: true,
+    });
+  }
+
+  function initPublicationSort() {
+    const grid = document.querySelector('#container-publications');
+    const keySelect = document.querySelector('.publication-sort-key');
+    const directionSelect = document.querySelector('.publication-sort-direction');
+    if (!grid || !keySelect || !directionSelect) return;
+
+    const sort = () => applyPublicationSort(grid, keySelect, directionSelect);
+    keySelect.addEventListener('change', sort);
+    directionSelect.addEventListener('change', sort);
+    sort();
+  }
+
+  function initCitationCopy() {
+    document.addEventListener(
+      'click',
+      function (event) {
+        const copyButton = event.target.closest('.js-copy-cite');
+        if (!copyButton) return;
+
+        const citation = document.querySelector('#modal .modal-body code');
+        if (!citation) return;
+
+        event.preventDefault();
+        event.stopImmediatePropagation();
+
+        const status = document.querySelector('.citation-modal__status');
+        navigator.clipboard
+          .writeText(citation.textContent)
+          .then(function () {
+            if (status) status.textContent = 'Copied';
+          })
+          .catch(function () {
+            if (status) status.textContent = 'Copy failed';
+          });
+      },
+      true,
+    );
+
+    document.addEventListener('click', function (event) {
+      if (!event.target.closest('.js-cite-modal')) return;
+      const status = document.querySelector('.citation-modal__status');
+      const error = document.querySelector('#modal-error');
+      if (status) status.textContent = '';
+      if (error) error.textContent = '';
+    });
+  }
+
+  onReady(function () {
+    initPublicationSort();
+    initCitationCopy();
+  });
+})();

--- a/assets/scss/template.scss
+++ b/assets/scss/template.scss
@@ -96,7 +96,7 @@ a:hover,
 
 // Homepage hero: full-width, image-led, and more institutional.
 #section-hero.wg-hero {
-  min-height: clamp(620px, 92vh, 900px);
+  min-height: unquote("clamp(620px, 92vh, 900px)");
   display: flex;
   align-items: center;
   position: relative;
@@ -121,7 +121,7 @@ a:hover,
 }
 
 #section-hero.wg-hero .row {
-  min-height: clamp(620px, 92vh, 900px);
+  min-height: unquote("clamp(620px, 92vh, 900px)");
   align-items: center;
 }
 
@@ -157,7 +157,7 @@ a:hover,
 #section-hero.wg-hero h1 {
   max-width: 980px;
   color: var(--np-white);
-  font-size: clamp(3.8rem, 8vw, 8.6rem);
+  font-size: unquote("clamp(3.8rem, 8vw, 8.6rem)");
   font-weight: 800;
   line-height: 0.94;
   text-align: left;
@@ -168,7 +168,7 @@ a:hover,
 #section-hero.wg-hero p {
   max-width: 760px;
   color: rgba(255, 255, 255, 0.88);
-  font-size: clamp(1.08rem, 1.7vw, 1.34rem);
+  font-size: unquote("clamp(1.08rem, 1.7vw, 1.34rem)");
   line-height: 1.72;
   text-align: left;
 }
@@ -201,13 +201,13 @@ a:hover,
 }
 
 .home-section:not(:first-of-type) {
-  padding: clamp(4.5rem, 7vw, 7rem) 0;
+  padding: unquote("clamp(4.5rem, 7vw, 7rem)") 0;
 }
 
 .home-section .section-heading h1,
 .home-section .section-heading h2 {
   color: var(--np-charcoal);
-  font-size: clamp(2.2rem, 4vw, 3.8rem);
+  font-size: unquote("clamp(2.2rem, 4vw, 3.8rem)");
   font-weight: 800;
   line-height: 1.04;
 }
@@ -270,7 +270,7 @@ a:hover,
 
 .article-container h1 {
   color: var(--np-charcoal);
-  font-size: clamp(2.25rem, 4.4vw, 4.7rem);
+  font-size: unquote("clamp(2.25rem, 4.4vw, 4.7rem)");
   font-weight: 800;
   line-height: 1.04;
   text-wrap: balance;
@@ -284,7 +284,7 @@ a:hover,
 .article-style h2 {
   color: var(--np-charcoal);
   margin-top: 3.2rem;
-  font-size: clamp(1.85rem, 3vw, 2.65rem);
+  font-size: unquote("clamp(1.85rem, 3vw, 2.65rem)");
   font-weight: 800;
   line-height: 1.08;
 }
@@ -292,7 +292,7 @@ a:hover,
 .article-style h3 {
   color: var(--np-cardinal);
   margin-top: 2.35rem;
-  font-size: clamp(1.22rem, 2vw, 1.52rem);
+  font-size: unquote("clamp(1.22rem, 2vw, 1.52rem)");
   font-weight: 800;
 }
 
@@ -325,6 +325,197 @@ a:hover,
   color: var(--np-charcoal-soft);
 }
 
+.publication-index .universal-wrapper h1::after {
+  margin-inline: auto;
+}
+
+.publication-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid rgba(46, 45, 41, 0.1);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 30px rgba(46, 45, 41, 0.06);
+}
+
+.publication-toolbar__primary,
+.publication-toolbar__sort {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.publication-toolbar .form-control {
+  min-width: 150px;
+  border-color: rgba(46, 45, 41, 0.16);
+  border-radius: 3px;
+  font-family: var(--np-heading-font);
+}
+
+.publication-toolbar .filter-search {
+  min-width: 260px;
+  max-width: 100%;
+}
+
+.publication-grid {
+  min-height: 10rem;
+}
+
+.publication-card {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 1.2rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.publication-card:hover {
+  transform: translateY(-2px);
+}
+
+.publication-card__cover {
+  width: 150px;
+  min-height: 200px;
+}
+
+.publication-card__cover a {
+  display: block;
+}
+
+.publication-card__cover img,
+.publication-card__cover-placeholder {
+  width: 150px;
+  aspect-ratio: 3 / 4;
+  border: 1px solid rgba(46, 45, 41, 0.12);
+  border-radius: 3px;
+  background: linear-gradient(145deg, #ffffff, #ece8df);
+  box-shadow: 0 12px 28px rgba(46, 45, 41, 0.1);
+}
+
+.publication-card__cover img {
+  height: auto;
+  object-fit: cover;
+}
+
+.publication-card__cover-placeholder {
+  display: grid;
+  place-items: center;
+  color: rgba(140, 21, 21, 0.42);
+  font-size: 2rem;
+}
+
+.publication-card__body {
+  min-width: 0;
+}
+
+.publication-card__meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.35rem;
+  color: var(--np-charcoal-soft);
+  font-family: var(--np-heading-font);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.publication-card__meta-row span:not(:last-child)::after {
+  content: "/";
+  margin-left: 0.45rem;
+  color: rgba(46, 45, 41, 0.3);
+}
+
+.publication-card__title {
+  margin: 0 0 0.45rem;
+  font-size: unquote("clamp(1.15rem, 2vw, 1.55rem)");
+  font-weight: 800;
+  line-height: 1.18;
+}
+
+.publication-card__title a {
+  color: var(--np-charcoal);
+  text-decoration: none;
+}
+
+.publication-card__title a:hover {
+  color: var(--np-cardinal);
+}
+
+.publication-card__authors {
+  margin-bottom: 0.35rem;
+  font-size: 0.96rem;
+}
+
+.publication-card__venue {
+  margin-bottom: 0.65rem;
+  color: var(--np-charcoal);
+  font-size: 0.96rem;
+}
+
+.publication-card__badges,
+.publication-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.publication-card__badges {
+  margin: 0.7rem 0;
+}
+
+.publication-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.55rem;
+  padding: 0.18rem 0.48rem;
+  border: 1px solid rgba(140, 21, 21, 0.22);
+  border-radius: 999px;
+  background: var(--np-cardinal-soft);
+  color: var(--np-cardinal-dark);
+  font-family: var(--np-heading-font);
+  font-size: 0.76rem;
+  font-weight: 750;
+}
+
+.publication-badge--muted {
+  border-color: rgba(46, 45, 41, 0.13);
+  background: rgba(46, 45, 41, 0.06);
+  color: var(--np-charcoal-soft);
+}
+
+.publication-badge--accent {
+  border-color: var(--np-cardinal);
+  background: var(--np-cardinal);
+  color: #fff;
+}
+
+.publication-card__links {
+  margin-top: 0.35rem;
+}
+
+.publication-card__links .btn {
+  padding: 0.42rem 0.65rem;
+  border-radius: 3px;
+}
+
+.citation-modal .modal-body pre {
+  max-height: unquote("min(56vh, 520px)");
+  margin-bottom: 0;
+  white-space: pre-wrap;
+}
+
+.citation-modal__status {
+  margin-right: auto;
+  color: var(--np-charcoal-soft);
+  font-family: var(--np-heading-font);
+  font-size: 0.88rem;
+}
+
 // Keep the theme's dark mode usable while preserving the red accent.
 .dark,
 body.dark {
@@ -346,9 +537,13 @@ body.dark .navbar {
 .dark .card,
 .dark .view-card .card,
 .dark .article-style blockquote,
+.dark .publication-toolbar,
+.dark .publication-card__cover-placeholder,
 body.dark .card,
 body.dark .view-card .card,
-body.dark .article-style blockquote {
+body.dark .article-style blockquote,
+body.dark .publication-toolbar,
+body.dark .publication-card__cover-placeholder {
   background: rgba(38, 37, 34, 0.94);
 }
 
@@ -373,7 +568,18 @@ body.dark .article-style blockquote {
   }
 
   #section-hero.wg-hero h1 {
-    font-size: clamp(3rem, 15vw, 5.4rem);
+    font-size: unquote("clamp(3rem, 15vw, 5.4rem)");
+  }
+
+  .publication-toolbar {
+    align-items: stretch;
+  }
+
+  .publication-toolbar,
+  .publication-toolbar__primary,
+  .publication-toolbar__sort,
+  .publication-toolbar .form-control {
+    width: 100%;
   }
 }
 
@@ -388,5 +594,30 @@ body.dark .article-style blockquote {
 
   .home-section:not(:first-of-type) {
     padding: 3.5rem 0;
+  }
+
+  .publication-card {
+    grid-template-columns: 96px minmax(0, 1fr);
+    gap: 0.85rem;
+    padding: 0.85rem;
+  }
+
+  .publication-card__cover {
+    width: 96px;
+    min-height: 128px;
+  }
+
+  .publication-card__cover img,
+  .publication-card__cover-placeholder {
+    width: 96px;
+  }
+
+  .publication-card__title {
+    font-size: 1.05rem;
+  }
+
+  .publication-card__authors,
+  .publication-card__venue {
+    font-size: 0.9rem;
   }
 }

--- a/content/en/publication/rn-691/cover.svg
+++ b/content/en/publication/rn-691/cover.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 400" role="img" aria-labelledby="title desc">
+  <title id="title">MXene infrared sensing cover preview</title>
+  <desc id="desc">A lightweight manually curated thumbnail for the MXene infrared sensing publication.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#2e2d29"/>
+      <stop offset="0.52" stop-color="#8c1515"/>
+      <stop offset="1" stop-color="#f7f7f5"/>
+    </linearGradient>
+    <radialGradient id="beam" cx="50%" cy="50%" r="60%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="0.28" stop-color="#ffdf9e" stop-opacity="0.74"/>
+      <stop offset="1" stop-color="#8c1515" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="300" height="400" fill="url(#bg)"/>
+  <circle cx="220" cy="92" r="104" fill="url(#beam)"/>
+  <g fill="none" stroke="#fff" stroke-opacity="0.48" stroke-width="2">
+    <path d="M-20 270 C70 220 125 330 210 280 C255 252 285 230 330 238"/>
+    <path d="M-18 302 C80 250 122 360 214 316 C265 292 292 278 330 286"/>
+    <path d="M-20 236 C62 196 122 294 198 246 C250 214 286 198 330 206"/>
+  </g>
+  <g transform="translate(58 126)" fill="#f7f7f5">
+    <rect x="0" y="0" width="184" height="118" rx="10" opacity="0.16"/>
+    <path d="M24 86 L76 34 L116 74 L146 44 L164 86 Z" opacity="0.9"/>
+    <circle cx="54" cy="42" r="12" opacity="0.8"/>
+  </g>
+  <text x="34" y="326" fill="#ffffff" font-family="Source Sans Pro, Arial, sans-serif" font-size="26" font-weight="700">Infrared Sensing</text>
+  <text x="34" y="354" fill="#ffffff" fill-opacity="0.82" font-family="Source Sans Pro, Arial, sans-serif" font-size="15">MXenes enabled by intercalants</text>
+</svg>

--- a/content/en/publication/rn-691/index.md
+++ b/content/en/publication/rn-691/index.md
@@ -22,6 +22,10 @@ publication_types:
 - article-journal
 publication: '*Advanced Optical Materials*'
 doi: 10.1002/adom.202200623
+cover_image: cover.svg
+research_areas:
+- Infrared Sensing
+- MXenes
 links:
 - name: URL
   url: https://doi.org/10.1002%2Fadom.202200623

--- a/content/zh/publication/rn-691/cover.svg
+++ b/content/zh/publication/rn-691/cover.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 400" role="img" aria-labelledby="title desc">
+  <title id="title">MXene infrared sensing cover preview</title>
+  <desc id="desc">A lightweight manually curated thumbnail for the MXene infrared sensing publication.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#2e2d29"/>
+      <stop offset="0.52" stop-color="#8c1515"/>
+      <stop offset="1" stop-color="#f7f7f5"/>
+    </linearGradient>
+    <radialGradient id="beam" cx="50%" cy="50%" r="60%">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="0.28" stop-color="#ffdf9e" stop-opacity="0.74"/>
+      <stop offset="1" stop-color="#8c1515" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="300" height="400" fill="url(#bg)"/>
+  <circle cx="220" cy="92" r="104" fill="url(#beam)"/>
+  <g fill="none" stroke="#fff" stroke-opacity="0.48" stroke-width="2">
+    <path d="M-20 270 C70 220 125 330 210 280 C255 252 285 230 330 238"/>
+    <path d="M-18 302 C80 250 122 360 214 316 C265 292 292 278 330 286"/>
+    <path d="M-20 236 C62 196 122 294 198 246 C250 214 286 198 330 206"/>
+  </g>
+  <g transform="translate(58 126)" fill="#f7f7f5">
+    <rect x="0" y="0" width="184" height="118" rx="10" opacity="0.16"/>
+    <path d="M24 86 L76 34 L116 74 L146 44 L164 86 Z" opacity="0.9"/>
+    <circle cx="54" cy="42" r="12" opacity="0.8"/>
+  </g>
+  <text x="34" y="326" fill="#ffffff" font-family="Source Sans Pro, Arial, sans-serif" font-size="26" font-weight="700">Infrared Sensing</text>
+  <text x="34" y="354" fill="#ffffff" fill-opacity="0.82" font-family="Source Sans Pro, Arial, sans-serif" font-size="15">MXenes enabled by intercalants</text>
+</svg>

--- a/content/zh/publication/rn-691/index.md
+++ b/content/zh/publication/rn-691/index.md
@@ -22,6 +22,10 @@ publication_types:
 - article-journal
 publication: '*Advanced Optical Materials*'
 doi: 10.1002/adom.202200623
+cover_image: cover.svg
+research_areas:
+- Infrared Sensing
+- MXenes
 links:
 - name: URL
   url: https://doi.org/10.1002%2Fadom.202200623

--- a/layouts/partials/citation.html
+++ b/layouts/partials/citation.html
@@ -1,0 +1,26 @@
+<!-- Citation modal -->
+<div id="modal" class="modal fade citation-modal" role="dialog" aria-labelledby="citation-modal-title" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="citation-modal-title">{{ i18n "btn_cite" }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <pre><code></code></pre>
+      </div>
+      <div class="modal-footer">
+        <span class="citation-modal__status" aria-live="polite"></span>
+        <a class="btn btn-outline-primary my-1 js-copy-cite" href="#">
+          <i class="fas fa-copy"></i> {{ i18n "btn_copy" }}
+        </a>
+        <a class="btn btn-outline-primary my-1 js-download-cite" href="#" target="_blank">
+          <i class="fas fa-download"></i> {{ i18n "btn_download" }}
+        </a>
+        <div id="modal-error"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/custom_js.html
+++ b/layouts/partials/custom_js.html
@@ -1,0 +1,7 @@
+{{ if eq .Type "publication" }}
+  {{ $publicationJS := resources.Get "js/publication-mvp.js" }}
+  {{ if $publicationJS }}
+    {{ $publicationJS = $publicationJS | js.Build (dict "format" "iife" "minify" true) }}
+    <script src="{{ $publicationJS.RelPermalink }}"></script>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/views/citation.html
+++ b/layouts/partials/views/citation.html
@@ -1,0 +1,99 @@
+{{ $item := .item }}
+
+{{ $cover := "" }}
+{{ $coverFull := "" }}
+{{ with $item.Params.cover_image }}
+  {{ $cover = $item.Resources.GetMatch . }}
+{{ end }}
+{{ with ($item.Params.cover_full_image | default $item.Params.cover_image) }}
+  {{ $coverFull = $item.Resources.GetMatch . }}
+{{ end }}
+{{ if and $cover (not $coverFull) }}
+  {{ $coverFull = $cover }}
+{{ end }}
+
+<article class="pub-list-item view-citation publication-card">
+  <div class="publication-card__cover" aria-hidden="{{ if $cover }}false{{ else }}true{{ end }}">
+    {{ if $cover }}
+      {{ $isStaticCover := or (eq $cover.MediaType.SubType "svg") (eq $cover.MediaType.SubType "gif") }}
+      {{ if $coverFull }}<a href="{{ $coverFull.RelPermalink }}" target="_blank" rel="noopener" aria-label="Open publication cover">{{ end }}
+        {{ if $isStaticCover }}
+          <img src="{{ $cover.RelPermalink }}" alt="{{ $item.Title }} cover" width="150" height="200" loading="lazy">
+        {{ else }}
+          {{ $coverThumb := $cover.Fill "300x400 webp" }}
+          {{ $coverThumb2x := $cover.Fill "600x800 webp" }}
+          <img src="{{ $coverThumb.RelPermalink }}"
+               srcset="{{ $coverThumb.RelPermalink }} 300w, {{ $coverThumb2x.RelPermalink }} 600w"
+               sizes="(max-width: 575px) 96px, 150px"
+               alt="{{ $item.Title }} cover"
+               width="{{ $coverThumb.Width }}"
+               height="{{ $coverThumb.Height }}"
+               loading="lazy">
+        {{ end }}
+      {{ if $coverFull }}</a>{{ end }}
+    {{ else }}
+      <div class="publication-card__cover-placeholder">
+        <i class="far fa-file-alt" aria-hidden="true"></i>
+      </div>
+    {{ end }}
+  </div>
+
+  <div class="publication-card__body">
+    <div class="publication-card__meta-row">
+      <span>{{ $item.Date.Format "2006" }}</span>
+      {{ with $item.Params.publication_types }}
+        <span>{{ i18n (printf "pub_%s" (strings.Replace (index . 0) "-" "_")) | default (strings.Title (index . 0)) }}</span>
+      {{ end }}
+    </div>
+
+    <h2 class="publication-card__title">
+      <a href="{{ $item.RelPermalink }}">{{ $item.Title }}</a>
+    </h2>
+
+    <div class="article-metadata li-cite-author publication-card__authors">
+      {{ partial "page_metadata_authors" $item }}
+    </div>
+
+    {{ if $item.Params.publication_short }}
+      <div class="publication-card__venue">{{ $item.Params.publication_short | markdownify }}</div>
+    {{ else if $item.Params.publication }}
+      <div class="publication-card__venue">{{ $item.Params.publication | markdownify }}</div>
+    {{ end }}
+
+    {{ if or (isset $item.Params "impact_factor") $item.Params.jcr_quartile (isset $item.Params "citation_count") $item.Params.research_areas $item.Params.badges }}
+    <div class="publication-card__badges">
+      {{ if isset $item.Params "impact_factor" }}
+        <span class="publication-badge">IF {{ $item.Params.impact_factor }}</span>
+      {{ end }}
+      {{ with $item.Params.jcr_quartile }}
+        <span class="publication-badge">{{ . }}</span>
+      {{ end }}
+      {{ if isset $item.Params "citation_count" }}
+        <span class="publication-badge">{{ $item.Params.citation_count }} citations</span>
+      {{ end }}
+      {{ with $item.Params.research_areas }}
+        {{ range . }}
+          <span class="publication-badge publication-badge--muted">{{ . }}</span>
+        {{ end }}
+      {{ end }}
+      {{ with $item.Params.badges }}
+        {{ range . }}
+          {{ $badge := . }}
+          {{ $label := cond (eq $badge "esi_highly_cited") "ESI Highly Cited" (cond (eq $badge "journal_cover") "Journal Cover" $badge) }}
+          <span class="publication-badge publication-badge--accent">{{ $label }}</span>
+        {{ end }}
+      {{ end }}
+    </div>
+    {{ end }}
+
+    <div class="publication-card__links btn-links">
+      {{ partial "page_links" (dict "page" $item "is_list" 1) }}
+      {{ with $item.Params.google_scholar_url }}
+        <a class="btn btn-outline-primary btn-page-header btn-sm" href="{{ . }}" target="_blank" rel="noopener">Scholar</a>
+      {{ end }}
+      {{ with $item.Params.orcid_url }}
+        <a class="btn btn-outline-primary btn-page-header btn-sm" href="{{ . }}" target="_blank" rel="noopener">ORCID</a>
+      {{ end }}
+    </div>
+  </div>
+</article>

--- a/layouts/section/publication.html
+++ b/layouts/section/publication.html
@@ -1,0 +1,106 @@
+{{- define "main" -}}
+
+{{ $.Page.Store.Set "has_isotope" true }}
+
+{{ partial "page_header.html" . }}
+
+<div class="universal-wrapper publication-index">
+  <div class="row">
+    <div class="col-lg-12">
+
+      {{ with .Content }}
+      <div class="article-style">{{ . }}</div>
+      {{ end }}
+
+      {{ range .Pages.ByDate.Reverse }}
+        {{ $year := print (.Date.Format "2006") }}
+        {{ $.Scratch.SetInMap "years" $year $year }}
+        {{ with .Params.research_areas }}
+          {{ range . }}
+            {{ $.Scratch.SetInMap "research_areas" (anchorize .) . }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+
+      <div class="publication-toolbar mb-4" aria-label="Publication controls">
+        <div class="publication-toolbar__primary">
+          <input type="search" class="filter-search form-control form-control-sm" placeholder="{{ i18n "search_placeholder" }}" autocapitalize="off"
+          autocomplete="off" autocorrect="off" role="textbox" spellcheck="false">
+
+          <select class="pub-filters pubtype-select form-control form-control-sm" data-filter-group="pubtype" aria-label="Publication type">
+            <option value="*">{{ i18n "publication_type" }}</option>
+            {{ range $index, $taxonomy := site.Taxonomies.publication_types }}
+            <option value=".pubtype-{{ $index }}">
+              {{ i18n (printf "pub_%s" (strings.Replace $index "-" "_")) | default (strings.Title $index) }}
+            </option>
+            {{ end }}
+          </select>
+
+          <select class="pub-filters form-control form-control-sm" data-filter-group="year" aria-label="{{ i18n "date" }}">
+            <option value="*">{{ i18n "date" }}</option>
+            {{ $years_sorted := $.Scratch.GetSortedMapValues "years" }}
+            {{ if $years_sorted }}
+            {{ range $year := sort $years_sorted "" "desc" }}
+            <option value=".year-{{ $year }}">
+              {{ $year }}
+            </option>
+            {{ end }}
+            {{ end }}
+          </select>
+
+          {{ $areas := $.Scratch.GetSortedMapValues "research_areas" }}
+          {{ if $areas }}
+          <select class="pub-filters form-control form-control-sm" data-filter-group="area" aria-label="Research area">
+            <option value="*">Research Area</option>
+            {{ range $area := sort $areas }}
+            <option value=".area-{{ anchorize $area }}">{{ $area }}</option>
+            {{ end }}
+          </select>
+          {{ end }}
+        </div>
+
+        <div class="publication-toolbar__sort">
+          <select class="publication-sort-key form-control form-control-sm" aria-label="Sort publications">
+            <option value="year">Sort: Year</option>
+            <option value="impact">Sort: Impact Factor</option>
+            <option value="citations">Sort: Citations</option>
+          </select>
+          <select class="publication-sort-direction form-control form-control-sm" aria-label="Sort direction">
+            <option value="desc">Desc</option>
+            <option value="asc">Asc</option>
+          </select>
+        </div>
+      </div>
+
+      <div id="container-publications" class="publication-grid">
+        {{ range $index, $item := .Pages.ByDate.Reverse }}
+
+        {{ if .Params.publication_types }}
+          {{ $.Scratch.Set "pubtype" (index .Params.publication_types 0) }}
+        {{ else }}
+          {{ $.Scratch.Set "pubtype" 0 }}
+        {{ end }}
+
+        {{ $areaClasses := slice }}
+        {{ with .Params.research_areas }}
+          {{ range . }}
+            {{ $areaClasses = $areaClasses | append (printf "area-%s" (anchorize .)) }}
+          {{ end }}
+        {{ end }}
+
+        <div class="grid-sizer col-lg-12 isotope-item pubtype-{{ $.Scratch.Get "pubtype" }} year-{{ .Date.Format "2006" }} {{ delimit $areaClasses " " }}"
+             data-pub-year="{{ .Date.Format "2006" }}"
+             data-pub-impact="{{ if isset .Params "impact_factor" }}{{ .Params.impact_factor }}{{ end }}"
+             data-pub-citations="{{ if isset .Params "citation_count" }}{{ .Params.citation_count }}{{ end }}"
+             data-sort-current="{{ .Date.Format "2006" }}">
+          {{ partial "functions/render_view" (dict "page" $ "item" . "view" ($.Params.view | default "compact") "index" $index) }}
+        </div>
+
+        {{ end }}
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{{- end -}}


### PR DESCRIPTION
## Summary

- Add local Hugo template overrides for the Publication section and citation list cards.
- Add publication cover thumbnails, research-area filtering, Year/IF/Citations sorting, and improved Cite modal feedback.
- Document the local-first publication metadata fields and manual cover/metric maintenance policy.

## Validation

- /private/tmp/codex-hugo-0.119.0/hugo --minify
- Playwright checks against http://127.0.0.1:1320/ for /publication/, /zh/publication/, /people/, and /post/26-05-07-csb-swir-cqd-review/.
- Verified no horizontal overflow on desktop/mobile Publication pages, area filtering, Cite modal BibTeX loading, and post Markdown image WebP srcset + lazy loading.

## Notes

This PR keeps Google Scholar, ORCID, IF/JCR, ESI, and cover data local/manual for MVP. It does not add automatic Crossref/OpenAlex/Google Scholar enrichment.